### PR TITLE
Fixed a crash when using keepAwake() on android 12 or later

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,12 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="de.appplant.cordova.plugin.background.ForegroundService" />
+            <service 
+                android:enabled="true"
+                android:exported="false"
+                android:foregroundServiceType="mediaPlayback"
+                android:name="de.appplant.cordova.plugin.background.ForegroundService"
+            />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">


### PR DESCRIPTION
Fixed a crash with the following log output
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.wingarc.djr.djrclientrc, PID: 407
    java.lang.RuntimeException: Unable to create service de.appplant.cordova.plugin.background.ForegroundService: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service appid/de.appplant.cordova.plugin.background.ForegroundService
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4504)
        at android.app.ActivityThread.access$1700(ActivityThread.java:247)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2076)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7842)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service appid/de.appplant.cordova.plugin.background.ForegroundService
        at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:54)
        at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:50)
        at android.os.Parcel.readParcelable(Parcel.java:3333)
        at android.os.Parcel.createExceptionOrNull(Parcel.java:2420)
        at android.os.Parcel.createException(Parcel.java:2409)
        at android.os.Parcel.readException(Parcel.java:2392)
        at android.os.Parcel.readException(Parcel.java:2334)
        at android.app.IActivityManager$Stub$Proxy.setServiceForeground(IActivityManager.java:7096)
        at android.app.Service.startForeground(Service.java:733)
        at de.appplant.cordova.plugin.background.ForegroundService.keepAwake(ForegroundService.java:132)
        at de.appplant.cordova.plugin.background.ForegroundService.onCreate(ForegroundService.java:100)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4491)
        at android.app.ActivityThread.access$1700(ActivityThread.java:247) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2076) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:201) 
        at android.os.Looper.loop(Looper.java:288) 
        at android.app.ActivityThread.main(ActivityThread.java:7842) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
E/com.marianhello.logging.UncaughtExceptionLogger: FATAL EXCEPTION: mainjava.lang.RuntimeException: Unable to create service de.appplant.cordova.plugin.background.ForegroundService: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service com.wingarc.djr.djrclientrc/de.appplant.cordova.plugin.background.ForegroundService
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4504)
        at android.app.ActivityThread.access$1700(ActivityThread.java:247)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2076)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7842)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service com.wingarc.djr.djrclientrc/de.appplant.cordova.plugin.background.ForegroundService
        at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:54)
        at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:50)
        at android.os.Parcel.readParcelable(Parcel.java:3333)
        at android.os.Parcel.createExceptionOrNull(Parcel.java:2420)
        at android.os.Parcel.createException(Parcel.java:2409)
        at android.os.Parcel.readException(Parcel.java:2392)
        at android.os.Parcel.readException(Parcel.java:2334)
        at android.app.IActivityManager$Stub$Proxy.setServiceForeground(IActivityManager.java:7096)
        at android.app.Service.startForeground(Service.java:733)
        at de.appplant.cordova.plugin.background.ForegroundService.keepAwake(ForegroundService.java:132)
        at de.appplant.cordova.plugin.background.ForegroundService.onCreate(ForegroundService.java:100)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4491)
    	... 9 common frames omitted
```